### PR TITLE
Moved "use strict" into CodingJS

### DIFF
--- a/coding.js
+++ b/coding.js
@@ -1,4 +1,4 @@
-"use strict";
+
 
 String.prototype.format = function () {
     var o = Array.prototype.slice.call(arguments);
@@ -11,6 +11,7 @@ String.prototype.format = function () {
 };
 
 var CodingJS = (function CodingJS() {
+    "use strict";
 
     return function CodingJSConstructor (interpreter_path, language, cbs) {
 


### PR DESCRIPTION
Having "use strict" in the main scope opts the entire page into strict
mode.

I am using codingjs in a project where I needed to do some things that
break strict mode. Making this change makes strict mode only apply to
the scope of CodingJS, not the caller.